### PR TITLE
Replace `np.float` with `np.float64`.

### DIFF
--- a/PythonAPI/pycocotools/cocoeval.py
+++ b/PythonAPI/pycocotools/cocoeval.py
@@ -375,8 +375,8 @@ class COCOeval:
                     tps = np.logical_and(               dtm,  np.logical_not(dtIg) )
                     fps = np.logical_and(np.logical_not(dtm), np.logical_not(dtIg) )
 
-                    tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                    fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                    tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float64)
+                    fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float64)
                     for t, (tp, fp) in enumerate(zip(tp_sum, fp_sum)):
                         tp = np.array(tp)
                         fp = np.array(fp)

--- a/PythonAPI/pycocotools/ytvoseval.py
+++ b/PythonAPI/pycocotools/ytvoseval.py
@@ -404,8 +404,8 @@ class YTVOSeval:
                     tps = np.logical_and(               dtm,  np.logical_not(dtIg) )
                     fps = np.logical_and(np.logical_not(dtm), np.logical_not(dtIg) )
 
-                    tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                    fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                    tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float64)
+                    fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float64)
                     for t, (tp, fp) in enumerate(zip(tp_sum, fp_sum)):
                         tp = np.array(tp)
                         fp = np.array(fp)


### PR DESCRIPTION
## Describe your changes
Replacing `np.float` with `np.float64` to support `numpy>=1.24.0`. The `np.float`,
`np.int`, etc. aliases were deprecated in NumPy 1.20 (see the [deprecation note](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)),
and deprecation has expired with NumPy 1.24 (Nov 24, 2022).

Using the current Pyhon API with newer Numpy versions will therefore raise the
following error:
```py
Traceback (most recent call last):
  ...
  File ".../lib/python3.8/site-packages/pycocotools/ytvoseval.py", line 407, in accumulate
    tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
  File ".../lib/python3.8/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy
scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

## Checklist before requesting a review
- [x] I have performed a self-review of my code

## Tests
Works on my machine